### PR TITLE
Replace 'chrome.extension.getURL' with 'chrome.runtime.getURL'

### DIFF
--- a/app/src/start.js
+++ b/app/src/start.js
@@ -6,7 +6,7 @@ chrome.storage.sync.get({
     if (!items.disabled) {
         var s = document.createElement('script');
         s.defer = true;
-        s.src = chrome.extension.getURL('src/background.js');
+        s.src = chrome.runtime.getURL('src/background.js');
         document.body.appendChild(s);
     }
 });


### PR DESCRIPTION
The `chrome.extension.getURL` function is deprecated. It should be replaced by using `chrome.runtime.getURL`.

https://developer.chrome.com/docs/extensions/reference/extension/#method-getURL

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getURL