### PR TITLE
Fix translating for playlist panel

### DIFF
--- a/app/src/background.js
+++ b/app/src/background.js
@@ -182,6 +182,7 @@ function untranslateOtherVideos() {
     untranslateArray(document.querySelectorAll('ytd-compact-video-renderer'));
     untranslateArray(document.querySelectorAll('ytd-grid-video-renderer'));
     untranslateArray(document.querySelectorAll('ytd-playlist-video-renderer'));
+    untranslateArray(document.querySelectorAll('ytd-playlist-panel-video-renderer'));
 
 
     // let compactVideos = document.getElementsByTagName('ytd-compact-video-renderer');    // related videos


### PR DESCRIPTION
The objects in the playlist panel, to the right of the main video, have the `ytd-playlist-panel-video-renderer` class.