### PR TITLE
Make it compatible with DeArrow

### DIFF
--- a/app/src/background.js
+++ b/app/src/background.js
@@ -55,7 +55,7 @@ function setTitleNode(text, afterNode) {
 }
 
 function untranslateCurrentVideo() {
-    const translatedTitleElement = document.querySelector("h1 > yt-formatted-string");
+    const translatedTitleElement = document.querySelector("h1 > yt-formatted-string:not(.cbCustomTitle)");
 
     // title link approach
     // if (document.querySelector(".ytp-title-link")) {


### PR DESCRIPTION
DeArrow is an extension that replaces titles with crowdsourced versions. There is a problem with yt-anti-translate writing to DeArrow's custom title element instead of the original element. 

It is much easier to fix on yt-anti-translate's side to make sure it writes to the original text element.

Fixes https://github.com/ajayyy/DeArrow/issues/88