### PR TITLE
[CI-FIX] use auto-wait to remove some tests flakiness

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,7 +23,7 @@ export default defineConfig<TestOptions>({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry 3 times on CI, or once locally */
-  retries: process.env.CI ? 3 : 1,
+  retries: process.env.CI ? 3 : 0,
   /* Limit parallel workers on CI as they cause random failures some of the times */
   workers: process.env.CI ? 2 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/tests/youtube-extension.extra.spec.ts
+++ b/tests/youtube-extension.extra.spec.ts
@@ -26,7 +26,7 @@ test.describe("YouTube Anti-Translate extension - Extras", () => {
     // --- Update Extension Settings and distribute a test copy ---
     // The object to be passed and inserted into the start.js file
     const configObject = { youtubeDataApiKey: process.env.YOUTUBE_API_KEY };
-    handleTestDistribution(configObject);
+    await handleTestDistribution(configObject);
 
     // Launch browser with the extension
     const context = await createBrowserContext(
@@ -75,7 +75,29 @@ test.describe("YouTube Anti-Translate extension - Extras", () => {
       localeString,
     );
 
-    await loadPageAndVerifyAuth(page, "https://www.youtube.com/@MrBeast");
+    await loadPageAndVerifyAuth(
+      page,
+      "https://www.youtube.com/watch?v=l-nMKJ5J3Uc",
+    );
+
+    try {
+      await page.waitForLoadState("networkidle", { timeout: 5000 });
+    } catch {}
+
+    try {
+      await Promise.all([
+        page.waitForNavigation({
+          waitUntil: "networkidle0",
+          timeout: 15_000,
+        }),
+        page.getByRole("link", { name: "MrBeast", exact: true }).click(),
+        page.waitForTimeout(5000),
+      ]);
+    } catch {}
+
+    try {
+      await page.waitForLoadState("networkidle", { timeout: 5000 });
+    } catch {}
 
     // Wait for the video grid to appear
     const channelHeaderSelector =
@@ -86,31 +108,50 @@ test.describe("YouTube Anti-Translate extension - Extras", () => {
     const channelTitleSelector = `${channelHeaderSelector} h1 .yt-core-attributed-string:visible`;
 
     console.log("Checking Channel header for original title...");
-    // Get the channel branding header title
+
+    // Check that the branding header title is in English and not in Thai
+    const channelTitleLocator = page.locator(channelTitleSelector);
+    try {
+      expect(channelTitleLocator).toHaveCount(1, {
+        timeout: 10000,
+      });
+    } catch {}
+    expect(channelTitleLocator).toContainText("MrBeast", {
+      timeout: 10000,
+    });
+    expect(channelTitleLocator).not.toContainText("มิสเตอร์บีสต์", {
+      timeout: 10000,
+    });
+    await expect(channelTitleLocator).toBeVisible();
+    // Log the channel branding header title
     const brandingTitle = await page
       .locator(channelTitleSelector)
       .textContent();
     console.log("Channel header title:", brandingTitle?.trim());
 
-    // Check that the branding header title is in English and not in Thai
-    expect(brandingTitle).toContain("MrBeast");
-    expect(brandingTitle).not.toContain("มิสเตอร์บีสต์");
-    await expect(page.locator(channelTitleSelector)).toBeVisible();
-
     // --- Check Branding Description
     const channelDescriptionSelector = `${channelHeaderSelector} yt-description-preview-view-model .truncated-text-wiz__truncated-text-content > .yt-core-attributed-string:nth-child(1)`;
 
     console.log("Checking Channel header for original description...");
-    // Get the channel branding header description
-    const brandingDescription = await page
-      .locator(channelDescriptionSelector)
-      .textContent();
-    console.log("Channel header description:", brandingTitle?.trim());
 
     // Check that the branding header title is in English and not in Thai
-    expect(brandingDescription).toContain("SUBSCRIBE FOR A COOKIE");
-    expect(brandingDescription).not.toContain("ไปดู Beast Games ได้แล้ว");
-    await expect(page.locator(channelDescriptionSelector)).toBeVisible();
+    const channelDescriptionLocator = page.locator(channelDescriptionSelector);
+    try {
+      expect(channelDescriptionLocator).toHaveCount(1, {
+        timeout: 10000,
+      });
+    } catch {}
+    expect(channelDescriptionLocator).toContainText("SUBSCRIBE FOR A COOKIE", {
+      timeout: 10000,
+    });
+    expect(channelDescriptionLocator).not.toContainText(
+      "ไปดู Beast Games ได้แล้ว",
+      { timeout: 10000 },
+    );
+    await expect(channelDescriptionLocator).toBeVisible();
+    // Log the channel branding header description
+    const brandingDescription = await channelDescriptionLocator.textContent();
+    console.log("Channel header description:", brandingDescription?.trim());
 
     // --- Open About Popup ---
     console.log(
@@ -122,32 +163,51 @@ test.describe("YouTube Anti-Translate extension - Extras", () => {
     try {
       await page.waitForLoadState("networkidle", { timeout: 5000 });
     } catch {}
-    await page.waitForTimeout(500);
 
     // --- Check About Popup ---
     const aboutContainer = "ytd-engagement-panel-section-list-renderer";
 
     const aboutTitleSelector = `${aboutContainer} #title-text:visible`;
     console.log("Checking Channel header for original description...");
-    // Get the about title
-    const aboutTitle = await page.locator(aboutTitleSelector).textContent();
-    console.log("Channel about title:", aboutTitle?.trim());
 
     // Check that the branding about title is in English and not in Thai
-    expect(aboutTitle).toContain("MrBeast");
-    expect(aboutTitle).not.toContain("มิสเตอร์บีสต์");
-    await expect(page.locator(aboutTitleSelector)).toBeVisible();
+    const aboutTitleLocator = page.locator(aboutTitleSelector);
+    try {
+      expect(aboutTitleLocator).toHaveCount(1, {
+        timeout: 10000,
+      });
+    } catch {}
+    expect(aboutTitleLocator).toContainText("MrBeast", {
+      timeout: 10000,
+    });
+    expect(aboutTitleLocator).not.toContainText("มิสเตอร์บีสต์", {
+      timeout: 10000,
+    });
+    await expect(aboutTitleLocator).toBeVisible();
+    // Log the about title
+    const aboutTitle = await aboutTitleLocator.textContent();
+    console.log("Channel about title:", aboutTitle?.trim());
 
     const aboutDescriptionSelector = `${aboutContainer} #description-container > .yt-core-attributed-string:nth-child(1):visible`;
-    // Get the about description
-    const aboutDescription = await page
-      .locator(aboutDescriptionSelector)
-      .textContent();
-    console.log("Channel about title:", aboutDescription?.trim());
+
     // Check that the branding about description is in English and not in Thai
-    expect(aboutDescription).toContain("SUBSCRIBE FOR A COOKIE");
-    expect(aboutDescription).not.toContain("ไปดู Beast Games ได้แล้ว");
-    await expect(page.locator(aboutDescriptionSelector)).toBeVisible();
+    const aboutDescriptionLocator = page.locator(aboutDescriptionSelector);
+    try {
+      expect(aboutDescriptionLocator).toHaveCount(1, {
+        timeout: 10000,
+      });
+    } catch {}
+    expect(aboutDescriptionLocator).toContainText("SUBSCRIBE FOR A COOKIE", {
+      timeout: 10000,
+    });
+    expect(aboutDescriptionLocator).not.toContainText(
+      "ไปดู Beast Games ได้แล้ว",
+      { timeout: 10000 },
+    );
+    await expect(aboutDescriptionLocator).toBeVisible();
+    // Log the about description
+    const aboutDescription = await aboutDescriptionLocator.textContent();
+    console.log("Channel about title:", aboutDescription?.trim());
 
     // --- Close Popup
     console.log("Clicking 'X' button to close Popup...");
@@ -159,7 +219,6 @@ test.describe("YouTube Anti-Translate extension - Extras", () => {
     try {
       await page.waitForLoadState("networkidle", { timeout: 5000 });
     } catch {}
-    await page.waitForTimeout(500);
 
     // --- Open About Popup via more links ---
     console.log(
@@ -173,27 +232,43 @@ test.describe("YouTube Anti-Translate extension - Extras", () => {
     try {
       await page.waitForLoadState("networkidle", { timeout: 5000 });
     } catch {}
-    await page.waitForTimeout(500);
 
     // --- Check About A second time via the moreLinks Popup ---
-    // Get the about title
-    const aboutTitle2 = await page.locator(aboutTitleSelector).textContent();
-    console.log("Channel about title:", aboutTitle?.trim());
 
     // Check that the branding about title is in English and not in Thai
-    expect(aboutTitle2).toContain("MrBeast");
-    expect(aboutTitle2).not.toContain("มิสเตอร์บีสต์");
-    await expect(page.locator(aboutTitleSelector)).toBeVisible();
+    try {
+      expect(aboutTitleLocator).toHaveCount(1, {
+        timeout: 10000,
+      });
+    } catch {}
+    expect(aboutTitleLocator).toContainText("MrBeast", {
+      timeout: 10000,
+    });
+    expect(aboutTitleLocator).not.toContainText("มิสเตอร์บีสต์", {
+      timeout: 10000,
+    });
+    await expect(aboutTitleLocator).toBeVisible();
+    // Log the about title
+    const aboutTitle2 = await aboutTitleLocator.textContent();
+    console.log("Channel about title:", aboutTitle2?.trim());
 
-    // Get the about description
-    const aboutDescription2 = await page
-      .locator(aboutDescriptionSelector)
-      .textContent();
-    console.log("Channel about title:", aboutDescription?.trim());
     // Check that the branding about description is in English and not in Thai
-    expect(aboutDescription2).toContain("SUBSCRIBE FOR A COOKIE");
-    expect(aboutDescription2).not.toContain("ไปดู Beast Games ได้แล้ว");
-    await expect(page.locator(aboutDescriptionSelector)).toBeVisible();
+    try {
+      expect(aboutDescriptionLocator).toHaveCount(1, {
+        timeout: 10000,
+      });
+    } catch {}
+    expect(aboutDescriptionLocator).toContainText("SUBSCRIBE FOR A COOKIE", {
+      timeout: 10000,
+    });
+    expect(aboutDescriptionLocator).not.toContainText(
+      "ไปดู Beast Games ได้แล้ว",
+      { timeout: 10000 },
+    );
+    await expect(aboutDescriptionLocator).toBeVisible();
+    // Log the about description
+    const aboutDescription2 = await aboutDescriptionLocator.textContent();
+    console.log("Channel about title:", aboutDescription2?.trim());
 
     // Take a screenshot for visual verification
     await page.screenshot({
@@ -210,19 +285,21 @@ test.describe("YouTube Anti-Translate extension - Extras", () => {
     try {
       await page.waitForLoadState("networkidle", { timeout: 5000 });
     } catch {}
-    await page.waitForTimeout(500);
+
+    // Check that the document title is in English and not in Thai
+    await page.waitForFunction(() => document.title.includes("MrBeast"), null, {
+      timeout: 5000,
+    });
+    // Check page title
+    const pageTitle = await page.title();
+    console.log("Document title for the Video is:", pageTitle?.trim());
+    expect(pageTitle).toContain("MrBeast");
+    expect(pageTitle).not.toContain("มิสเตอร์บีสต์");
 
     // Take a screenshot for visual verification
     await page.screenshot({
       path: `images/tests/${browserNameWithExtensions}/${localeString}/youtube-channel-branding-header${addToScreenshotName}-test.png`,
     });
-
-    // Check page title
-    const pageTitle = await page.title();
-    console.log("Document title for the Video is:", pageTitle?.trim());
-    // Check that the document title is in English and not in Thai
-    expect(pageTitle).toContain("MrBeast");
-    expect(pageTitle).not.toContain("มิสเตอร์บีสต์");
 
     // Check console message count
     expect(consoleMessageCount).toBeLessThan(2000);
@@ -261,19 +338,29 @@ test.describe("YouTube Anti-Translate extension - Extras", () => {
 
     // --- Check Branding Title ---
     const videoAuthorSelector = `#upload-info.ytd-video-owner-renderer yt-formatted-string a`;
+    const videoAuthorLocator = page.locator(videoAuthorSelector);
 
     console.log("Checking video author for original author...");
-    // Get the channel branding header title
-    const brandingTitle = await page.locator(videoAuthorSelector).textContent();
-    console.log("Video author:", brandingTitle?.trim());
 
     // Check that the channel name is in English and not in Thai
-    expect(brandingTitle).toContain("MrBeast");
-    expect(brandingTitle).not.toContain("มิสเตอร์บีสต์");
-    await expect(page.locator(videoAuthorSelector)).toBeVisible();
+    expect(videoAuthorLocator).toHaveCount(1, {
+      timeout: 10000,
+    });
+    expect(videoAuthorLocator).toContainText("MrBeast", {
+      timeout: 10000,
+    });
+    expect(videoAuthorLocator).not.toContainText("มิสเตอร์บีสต์", {
+      timeout: 10000,
+    });
+    await expect(videoAuthorLocator).toBeVisible();
+    // Log the channel branding header title
+    const brandingTitle = await videoAuthorLocator.textContent();
+    console.log("Video author:", brandingTitle?.trim());
 
     // Take a screenshot for visual verification
-    await page.waitForTimeout(4000);
+    const target = page.locator("ytd-video-owner-renderer yt-icon div");
+    await expect(target).toHaveCount(1, { timeout: 20000 }); // Ensure it exists
+    await expect(target).toBeVisible({ timeout: 20000 }); // Then check visibility
     await page.screenshot({
       path: `images/tests/${browserNameWithExtensions}/${localeString}/youtube-video-author-test.png`,
     });

--- a/tests/youtube-extension.spec.ts
+++ b/tests/youtube-extension.spec.ts
@@ -30,6 +30,16 @@ test.describe("YouTube Anti-Translate extension", () => {
       browserNameWithExtensions,
     );
 
+    try {
+      await Promise.all([
+        page.waitForNavigation({
+          waitUntil: "networkidle0",
+          timeout: 15_000,
+        }),
+        page.waitForTimeout(5000),
+      ]);
+    } catch {}
+
     // Wait for the video page to fully load
     await page.waitForSelector("ytd-watch-metadata");
 
@@ -40,7 +50,7 @@ test.describe("YouTube Anti-Translate extension", () => {
     if (await moreButton.isVisible()) {
       await moreButton.click();
       // Wait for the description to expand
-      await page.waitForTimeout(1000);
+      await page.waitForTimeout(5000);
     }
 
     // Get the description text
@@ -49,28 +59,27 @@ test.describe("YouTube Anti-Translate extension", () => {
       .textContent();
     console.log("Description text:", descriptionText?.trim());
 
-    // Get the video title
-    const videoTitle = await page
-      .locator(
-        "h1.ytd-watch-metadata #yt-anti-translate-fake-node-current-video:visible",
-      )
-      .textContent();
-    console.log("Video title:", videoTitle?.trim());
+    const videoTitleLocator = page.locator(
+      "h1.ytd-watch-metadata #yt-anti-translate-fake-node-current-video:visible",
+    );
 
     // Check that the title is in English and not in Russian
-    expect(videoTitle).toContain("Ages 1 - 100 Decide Who Wins $250,000");
-    expect(videoTitle).not.toContain(
-      "Люди от 1 до 100 Лет Решают, кто Выиграет $250,000",
+    try {
+      expect(videoTitleLocator).toHaveCount(1, {
+        timeout: 10000,
+      });
+    } catch {}
+    expect(videoTitleLocator).toContainText(
+      "Ages 1 - 100 Decide Who Wins $250,000",
+      { timeout: 10000 },
     );
-
-    // Check page title
-    const pageTitle = await page.title();
-    console.log("Document title for the Video is:", pageTitle?.trim());
-    // Check that the document title is in English and not in Russian
-    expect(pageTitle).toContain("Ages 1 - 100 Decide Who Wins $250,000");
-    expect(pageTitle).not.toContain(
+    expect(videoTitleLocator).not.toContainText(
       "Люди от 1 до 100 Лет Решают, кто Выиграет $250,000",
+      { timeout: 10000 },
     );
+    // log the video title
+    const videoTitle = await videoTitleLocator.textContent();
+    console.log("Video title:", videoTitle?.trim());
 
     // Take a screenshot for visual verification
     await page.screenshot({
@@ -81,37 +90,50 @@ test.describe("YouTube Anti-Translate extension", () => {
     await page.keyboard.press("F");
     await page.waitForTimeout(500);
 
-    // Get the head link video title
-    const headLinkVideoTitle = await page
-      .locator(
-        "ytd-player .html5-video-player a.ytp-title-link#yt-anti-translate-fake-node-video-head-link",
-      )
-      .textContent();
+    const headLinkVideoTitleLocator = page.locator(
+      "ytd-player .html5-video-player a.ytp-title-link#yt-anti-translate-fake-node-video-head-link",
+    );
+
+    // Check that the title is in English and not in Russian
+    try {
+      expect(headLinkVideoTitleLocator).toHaveCount(1, {
+        timeout: 10000,
+      });
+    } catch {}
+    expect(headLinkVideoTitleLocator).toContainText(
+      "Ages 1 - 100 Decide Who Wins $250,000",
+      { timeout: 10000 },
+    );
+    expect(headLinkVideoTitleLocator).not.toContainText(
+      "Люди от 1 до 100 Лет Решают, кто Выиграет $250,000",
+      { timeout: 10000 },
+    );
+    // Log the head link video title
+    const headLinkVideoTitle = await headLinkVideoTitleLocator.textContent();
     console.log("Head Link Video title:", headLinkVideoTitle?.trim());
 
-    // Check that the title is in English and not in Russian
-    expect(headLinkVideoTitle).toContain(
-      "Ages 1 - 100 Decide Who Wins $250,000",
-    );
-    expect(headLinkVideoTitle).not.toContain(
-      "Люди от 1 до 100 Лет Решают, кто Выиграет $250,000",
+    const fullStreenVideoTitleFooterLocator = page.locator(
+      "ytd-player .html5-video-player div.ytp-fullerscreen-edu-text#yt-anti-translate-fake-node-fullscreen-edu",
     );
 
-    // Get the full screen footer video title
-    const fullStreenVideoTitleFooter = await page
-      .locator(
-        "ytd-player .html5-video-player div.ytp-fullerscreen-edu-text#yt-anti-translate-fake-node-fullscreen-edu",
-      )
-      .textContent();
+    // Check that the title is in English and not in Russian
+    try {
+      expect(fullStreenVideoTitleFooterLocator).toHaveCount(1, {
+        timeout: 10000,
+      });
+    } catch {}
+    expect(fullStreenVideoTitleFooterLocator).toContainText(
+      "Ages 1 - 100 Decide Who Wins $250,000",
+      { timeout: 10000 },
+    );
+    expect(fullStreenVideoTitleFooterLocator).not.toContainText(
+      "Люди от 1 до 100 Лет Решают, кто Выиграет $250,000",
+      { timeout: 10000 },
+    );
+    // Log the full screen footer video title
+    const fullStreenVideoTitleFooter =
+      await fullStreenVideoTitleFooterLocator.textContent();
     console.log("Head Link Video title:", fullStreenVideoTitleFooter?.trim());
-
-    // Check that the title is in English and not in Russian
-    expect(fullStreenVideoTitleFooter).toContain(
-      "Ages 1 - 100 Decide Who Wins $250,000",
-    );
-    expect(fullStreenVideoTitleFooter).not.toContain(
-      "Люди от 1 до 100 Лет Решают, кто Выиграет $250,000",
-    );
 
     // Take a screenshot for visual verification
     await page.screenshot({
@@ -122,22 +144,48 @@ test.describe("YouTube Anti-Translate extension", () => {
     await page.keyboard.press("F");
     await page.waitForTimeout(500);
 
-    await page
-      .locator("#description-inline-expander:visible")
-      .scrollIntoViewIfNeeded();
-    // Check that the description contains the original English text and not the Russian translation
-    expect(descriptionText).toContain("believe who they picked");
-    expect(descriptionText).toContain(
-      "Thanks Top Troops for sponsoring this video",
+    const descriptionLocator = page.locator(
+      "#description-inline-expander:visible",
     );
-    expect(descriptionText).not.toContain(
+    try {
+      expect(descriptionLocator).toHaveCount(1, {
+        timeout: 10000,
+      });
+    } catch {}
+    await descriptionLocator.scrollIntoViewIfNeeded();
+    // Check that the description contains the original English text and not the Russian translation
+    expect(descriptionLocator).toContainText("believe who they picked", {
+      timeout: 10000,
+    });
+    expect(descriptionLocator).toContainText(
+      "Thanks Top Troops for sponsoring this video",
+      { timeout: 10000 },
+    );
+    expect(descriptionLocator).not.toContainText(
       "Я не могу поверить, кого они выбрали",
+      { timeout: 10000 },
     );
 
     // Take a screenshot for visual verification
     await page.screenshot({
       path: `images/tests/${browserNameWithExtensions}/${localeString}/youtube-extension-test-description.png`,
     });
+
+    await page.waitForFunction(
+      () => document.title.includes("Ages 1 - 100 Decide Who Wins $250,000"),
+      null,
+      {
+        timeout: 10000,
+      },
+    );
+    // Check page title
+    const pageTitle = await page.title();
+    console.log("Document title for the Video is:", pageTitle?.trim());
+    // Check that the document title is in English and not in Russian
+    expect(pageTitle).toContain("Ages 1 - 100 Decide Who Wins $250,000");
+    expect(pageTitle).not.toContain(
+      "Люди от 1 до 100 Лет Решают, кто Выиграет $250,000",
+    );
 
     // Check console message count
     expect(consoleMessageCount).toBeLessThan(2000);
@@ -185,18 +233,31 @@ test.describe("YouTube Anti-Translate extension", () => {
     await page.waitForTimeout(1000);
 
     // Get the description text to verify it's in English (not translated)
-    const descriptionText = await page
-      .locator("#description-inline-expander:visible")
-      .textContent();
-    console.log("Description text:", descriptionText?.trim());
-
-    // Verify description contains expected English text
-    expect(descriptionText).toContain(
-      "Toy Rockets Challenge - Fun Outdoor Activities for kids!",
+    const descriptionLocator = page.locator(
+      "#description-inline-expander:visible",
     );
-    expect(descriptionText).toContain("Chris helps Alice find her cars");
-    expect(descriptionText).toContain("Please Subscribe!");
-    expect(descriptionText).not.toContain("Запуск ракет"); // Should not contain Russian translation
+    // Verify description contains expected English text
+    try {
+      expect(descriptionLocator).toHaveCount(1, {
+        timeout: 10000,
+      });
+    } catch {}
+    expect(descriptionLocator).toContainText(
+      "Toy Rockets Challenge - Fun Outdoor Activities for kids!",
+      { timeout: 10000 },
+    );
+    expect(descriptionLocator).toContainText(
+      "Chris helps Alice find her cars",
+      { timeout: 10000 },
+    );
+    expect(descriptionLocator).toContainText("Please Subscribe!", {
+      timeout: 10000,
+    });
+    expect(descriptionLocator).not.toContainText("Запуск ракет", {
+      timeout: 10000,
+    }); // Should not contain Russian translation
+    const descriptionText = await descriptionLocator.textContent();
+    console.log("Description text:", descriptionText?.trim());
 
     // Click on the second timecode (05:36)
     const secondTimecodeSelector = 'a[href*="t=336"]'; // 5:36 = 336 seconds
@@ -254,36 +315,55 @@ test.describe("YouTube Anti-Translate extension", () => {
     const shortsTitleSelector = "yt-shorts-video-title-view-model > h2 > span";
     await page.waitForSelector(shortsTitleSelector);
 
-    // Get the title text
-    const titleElement = page.locator(shortsTitleSelector);
-    const shortsTitle = await titleElement.textContent();
-    console.log("Shorts title:", shortsTitle?.trim());
-
     // Verify the title is the original English one and not the Russian translation
-    expect(shortsTitle?.trim()).toBe("Highest Away From Me Wins $10,000");
-    expect(shortsTitle?.trim()).not.toBe("Достигни Вершины И Выиграй $10,000");
-    await expect(page.locator(shortsTitleSelector)).toBeVisible();
-
-    // Check page title
-    const pageTitle = await page.title();
-    console.log("Document title for the Short is:", pageTitle?.trim());
-    // Check that the document title is in English and not in Russian
-    expect(pageTitle).toContain("Highest Away From Me Wins $10,000");
-    expect(pageTitle).not.toContain("Достигни Вершины И Выиграй $10,000");
+    const titleLocator = page.locator(shortsTitleSelector);
+    try {
+      expect(titleLocator).toHaveCount(1, {
+        timeout: 10000,
+      });
+    } catch {}
+    expect(titleLocator).toHaveText("Highest Away From Me Wins $10,000", {
+      timeout: 10000,
+    });
+    expect(titleLocator).not.toHaveText("Достигни Вершины И Выиграй $10,000", {
+      timeout: 10000,
+    });
+    expect(titleLocator).toBeVisible({ timeout: 10000 });
+    // Log the title text
+    const shortsTitle = await titleLocator.textContent();
+    console.log("Shorts title:", shortsTitle?.trim());
 
     // Wait for the shorts video link element to be present
     const shortsVideoLinkSelector =
       ".ytReelMultiFormatLinkViewModelEndpoint span.yt-core-attributed-string>span:visible";
     await page.waitForSelector(shortsVideoLinkSelector);
 
-    // Get the title text
-    const titleLinkElement = page.locator(shortsVideoLinkSelector);
-    const shortsLinkTitle = await titleLinkElement.textContent();
+    // Verify the title is the has English characters and not russian
+    const titleLinkLocator = page.locator(shortsVideoLinkSelector);
+    try {
+      expect(titleLinkLocator).toHaveCount(1, {
+        timeout: 10000,
+      });
+    } catch {}
+    expect(titleLinkLocator).toHaveText(/[A-Za-z]/, { timeout: 10000 }); // Checks for any English letters
+    expect(titleLinkLocator).not.toHaveText(/[А-Яа-яЁё]/, { timeout: 10000 }); // Ensures no Russian letters
+    // Log the title text
+    const shortsLinkTitle = await titleLinkLocator.textContent();
     console.log("Shorts Link title:", shortsLinkTitle?.trim());
 
-    // Verify the title is the has English characters and not russian
-    expect(shortsLinkTitle?.trim()).toMatch(/[A-Za-z]/); // Checks for any English letters
-    expect(shortsLinkTitle?.trim()).not.toMatch(/[А-Яа-яЁё]/); // Ensures no Russian letters
+    await page.waitForFunction(
+      () => document.title.includes("Highest Away From Me Wins $10,000"),
+      null,
+      {
+        timeout: 10000,
+      },
+    );
+    // Check page title
+    const pageTitle = await page.title();
+    console.log("Document title for the Short is:", pageTitle?.trim());
+    // Check that the document title is in English and not in Russian
+    expect(pageTitle).toContain("Highest Away From Me Wins $10,000");
+    expect(pageTitle).not.toContain("Достигни Вершины И Выиграй $10,000");
 
     // Take a screenshot for visual verification
     await page.screenshot({


### PR DESCRIPTION
- Use expects with auto-wait checks to make tests less flaky
- Added "EBUSY" check in `handleTestDistribution` as concurrent tests both using the testDist could fail when doing `modifyStartJs`