### PR TITLE
[CI-FIX] Pull request target for Playwright Workflow

### DIFF
--- a/.github/workflows/remove-safe-to-test-label.yml
+++ b/.github/workflows/remove-safe-to-test-label.yml
@@ -1,0 +1,30 @@
+name: Remove Safe-to-Test Label
+
+on:
+  pull_request_target:
+    types: [synchronize]
+    branches: [main]
+
+jobs:
+  remove-safe-to-test:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Require 'safe-to-test' label
+        id: require-label
+        uses: mheap/github-action-required-labels@v5
+        with:
+          mode: minimum
+          count: 1
+          labels: "safe-to-test"
+          exit_type: success
+
+      - name: Remove "safe-to-test" label
+        if: contains(steps.require-label.outputs.labels, 'safe-to-test')
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: "safe-to-test"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,9 @@ name: Playwright
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main, master, release*]
+  pull_request_target:
+    types: [labeled, unlabeled]
+    branches: [main]
   schedule:
     - cron: "0 0 * * 0,2,4" # Run at midnight UTC every Sunday and Tuesday and Thursday
 
@@ -16,9 +17,25 @@ jobs:
     name: Tests YT Anti Translate Extension with xvfb-run Headed
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Require 'safe-to-test' label
+        uses: mheap/github-action-required-labels@v5
+        with:
+          mode: minimum
+          count: 1
+          labels: "safe-to-test"
+          add_comment: true
+
+      - name: Checkout PR code or main
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.ref || 'main' }}
+
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*


### PR DESCRIPTION
- Change `test.yml` to trigger on `pull_request_target` exclusively for `types: [labeled, unlabeled]` and check that the "sefe-to-test" label was added to the PR before any `actions/checkout@v4`
- add `.github/workflows/remove-safe-to-test-label.yml` to automatically remove the "safe-to-test" label at every `synchronise` so that any new commit pushed removes the permission to run the test till new code is rechecked.

## Disclamer
the `test.yml` will not run with this PR cause the trigger in main differs so it is ignored by GitHub for security reasons