### PR TITLE
[CI-FIX] Fix bug #49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.3]
+
+### Fixed
+
+- Fix bug #49
+
 ## [1.18.2] - 2025-05-27
 
 ### New Feature

--- a/app/src/options.js
+++ b/app/src/options.js
@@ -62,7 +62,13 @@ function renderFooterLinks() {
 
 function saveOptions() {
   if (document.getElementById("reload-checkbox").checked) {
-    chrome.tabs.reload();
+    chrome.tabs.query({}, function (tabs) {
+      for (const tab of tabs) {
+        if (tab.url && tab.url.match(/^.*youtube\.com\/.{0,}$/)) {
+          chrome.tabs.reload(tab.id);
+        }
+      }
+    });
   }
   chrome.storage.sync.get(
     {


### PR DESCRIPTION
Updated `options.js' so that for reloads, it finds any tab matching `^.*youtube\.com\/.{0,}$` and only reloads those. This way YouTube page is reloaded also if YouTube is not the current tab