### PR TITLE
small fix for Playwright yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [main]
   pull_request_target:
-    types: [labeled, unlabeled]
+    types: [opened, labeled, unlabeled]
     branches: [main]
   schedule:
     - cron: "0 0 * * 0,2,4" # Run at midnight UTC every Sunday and Tuesday and Thursday
@@ -23,6 +23,7 @@ jobs:
 
     steps:
       - name: Require 'safe-to-test' label
+        if: github.event_name == 'pull_request_target'
         uses: mheap/github-action-required-labels@v5
         with:
           mode: minimum


### PR DESCRIPTION
- Add `pull_request_target` type `opened` so that the check is allowed to fail on newly opened PRs.
- Make `Require 'safe-to-test' label` required only if the trigger is `pull_request_target`. Skip when that is not the triggering event