### PR TITLE
Fix 'release.yml' not getting github token when PR is from fork

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ name: Create Release with tag
 # CHANGELOG.md is used to populate the body of the release before any auto generated notes
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
     branches:
@@ -16,7 +16,7 @@ on:
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request_target.merged == true
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Update trigger to "Pull_request_target" so that it has alwas access to secrets even when PR is from fork.
As in https://github.com/zpix1/yt-anti-translate/actions/runs/15793042404/job/44524095923#step:8:1 

No security considerations needed as release.yml only runs on PR closed and merged

Code is already merged when this runs so we just checkout main