### PR TITLE
notifications untranslation feature bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix notification untranslation not working due to a typo, and add handle for ':'
+
 ## [1.19.2] - 2025-07-22
 
 ### New Feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.19.3] - 2025-07-23
+
 ### Fixed
 
 - Fix notification untranslation not working due to a typo, and add handle for ':'

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "YouTube Anti Translate",
   "author": "zpix1",
-  "version": "1.19.2",
+  "version": "1.19.3",
   "description": "A small extension to disable YouTube video titles/audio/descriptions autotranslation.",
   "manifest_version": 3,
   "browser_specific_settings": {

--- a/app/pages/popup.html
+++ b/app/pages/popup.html
@@ -237,7 +237,7 @@
   <body id="yt-anti-translate">
     <div class="scroll-wrapper">
       <div class="container">
-        <div class="header">YT Anti Translate 1.19.2</div>
+        <div class="header">YT Anti Translate 1.19.3</div>
         <div id="permission-warning" style="display: none; margin-top: 15px;">
           <div class="small" style="color: red;">
             <p><strong>Permission to access YouTube is not granted.</strong></p>

--- a/app/src/background_notifications.js
+++ b/app/src/background_notifications.js
@@ -137,7 +137,7 @@ function replaceVideoTitleInNotification(message, originalTitle) {
   }
 
   // Handle :
-  const colonIdx = message.lastIndexOf(":");
+  const colonIdx = message.indexOf(":");
   if (colonIdx !== -1) {
     return message.slice(0, colonIdx + 1) + " " + originalTitle;
   }

--- a/app/src/background_notifications.js
+++ b/app/src/background_notifications.js
@@ -29,7 +29,7 @@ function extractVideoIdFromUrl(url) {
 async function fetchOriginalTitle(videoId) {
   const cacheKey = `ytat_oembed_${videoId}`;
   const cached = window.YoutubeAntiTranslate.getSessionCache(cacheKey);
-  if (cached !== null) {
+  if (cached) {
     return { originalTitle: cached };
   }
 
@@ -134,6 +134,12 @@ function replaceVideoTitleInNotification(message, originalTitle) {
         message.slice(0, startIdx + 1) + originalTitle + message.slice(endIdx)
       );
     }
+  }
+
+  // Handle :
+  const colonIdx = message.lastIndexOf(":");
+  if (colonIdx !== -1) {
+    return message.slice(0, colonIdx + 1) + " " + originalTitle;
   }
 
   // Fallback – return originalTitle


### PR DESCRIPTION
Fix bug caused by an explicit `null` comparison (value is `undefined` and add proper handling of `:` notifications