### PR TITLE
[CI-FIX] fully qualify path to script

### DIFF
--- a/.github/workflows/publish-firefox.yml
+++ b/.github/workflows/publish-firefox.yml
@@ -106,7 +106,7 @@ jobs:
         if: steps.sign_step.outputs.status == '0' || steps.sign_step.outputs.status == '124'
         run: |
           npm install jsonwebtoken@9.0.2 dotenv@16.5.0
-          node scripts/mozilla_amo_version_patch.js
+          node .github/workflows/scripts/mozilla_amo_version_patch.js
         env:
           AMO_JWT_ISSUER: ${{ secrets.AMO_JWT_ISSUER }}
           AMO_JWT_SECRET: ${{ secrets.AMO_JWT_SECRET }}


### PR DESCRIPTION
fully qualify path to `.github/workflows/scripts/mozilla_amo_version_patch.js` inside of `publish-firefox.yml`