### PR TITLE
[CI-FIX] Add missing checkout to publish-firefox.yml

### DIFF
--- a/.github/workflows/publish-firefox.yml
+++ b/.github/workflows/publish-firefox.yml
@@ -63,6 +63,9 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: "18"
+      
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Download bundle artifact
         uses: actions/download-artifact@v4

--- a/app/src/background_description.js
+++ b/app/src/background_description.js
@@ -577,7 +577,7 @@ function fetchOriginalDescription() {
     return null;
   }
 
-  return playerResponse.videoDetails?.shortDescription || null;
+  return playerResponse?.videoDetails?.shortDescription || null;
 }
 
 /**

--- a/app/src/global.js
+++ b/app/src/global.js
@@ -1283,6 +1283,6 @@ ytm-shorts-lockup-view-model`,
       window.YoutubeAntiTranslate.setSessionCache(cacheKey, title);
       return { response: response.response, data: { title: title } };
     }
-    return { response: response.response, data: null };
+    return { response: response?.response, data: null };
   },
 };


### PR DESCRIPTION
- Add missing checkout to publish-firefox.yml in the second job so that the script file `mozilla_amo_version_patch.js` is in the job workspace
- added to missing ? for safely accessing properties on `global.js` and `backgroud_description.js`