### PR TITLE
fix: #106, debounce in background is not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix [#106](https://github.com/zpix1/yt-anti-translate/issues/106) document title doesn't get untranslated when tab is backgrounded
 - Fix [#109](https://github.com/zpix1/yt-anti-translate/issues/109) issues with videos in playlists
+- Fix [#108](https://github.com/zpix1/yt-anti-translate/issues/108) issues with title untranslating without player available
 
 ## [1.19.9] - 2025-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.19.10] - 2025-08-08
 
+### New Feature
+
+- [#105](https://github.com/zpix1/yt-anti-translate/issues/105) Untranslate channel names on Collaborators pop-up
+
 ### Fixed
 
 - Fix [#106](https://github.com/zpix1/yt-anti-translate/issues/106) document title doesn't get untranslated when tab is backgrounded
+- Fix [#109](https://github.com/zpix1/yt-anti-translate/issues/109) issues with videos in playlists
 
 ## [1.19.9] - 2025-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.19.10] - 2025-08-08
+
+### Fixed
+
+- Fix [#106](https://github.com/zpix1/yt-anti-translate/issues/106) document title doesn't get untranslated when tab is backgrounded
+
 ## [1.19.9] - 2025-08-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -18,9 +18,12 @@ It is much easier to use than its analogues (such as [YoutubeAutotranslateCancel
 
 - Restores original video titles on YouTube (Title Anti-Translation)
 - Restores original video descriptions on YouTube (can be toggled in settings "Untranslate description")
+- Restores original video chapters
 - Disables automatic audio (dubbing) translation (can be toggled in settings "Untranslate audio track")
 - Restores original channel branding header and about on YouTube (can be toggled in settings "Untranslate channel branding")
+- Restores original channels' names almost everywhere
 - Untranslates YouTube Shorts audio and titles
+- Works on m.youtube.com too (some mobile features are still unsupported and/or experimental)
 - Works automatically without any configuration
 
 ### Enhanced Features Reliability Option

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "YouTube Anti Translate",
   "author": "zpix1",
-  "version": "1.19.9.1",
+  "version": "1.19.10",
   "description": "A small extension to disable YouTube video titles/audio/descriptions autotranslation.",
   "manifest_version": 3,
   "browser_specific_settings": {

--- a/app/pages/popup.html
+++ b/app/pages/popup.html
@@ -239,7 +239,7 @@
   <body id="yt-anti-translate">
     <div class="scroll-wrapper">
       <div class="container">
-        <div class="header">YT Anti Translate 1.19.9</div>
+        <div class="header">YT Anti Translate 1.19.10</div>
         <div id="permission-warning" style="display: none; margin-top: 15px;">
           <div class="small" style="color: red;">
             <p><strong>Permission to access YouTube is not granted.</strong></p>

--- a/app/src/background.js
+++ b/app/src/background.js
@@ -167,6 +167,7 @@ async function untranslateCurrentVideo() {
     originalNodeSelector,
     () => document.location.href,
     "div",
+    false,
     true,
   );
 }
@@ -255,6 +256,7 @@ async function untranslateCurrentMobileFeaturedVideoChannel() {
     originalNodeSelector,
     (el) => el.closest("a").href,
     "span",
+    false,
     true,
   );
 }
@@ -265,6 +267,7 @@ async function untranslateCurrentMobileFeaturedVideoChannel() {
  * @param {string} originalNodeSelector
  * @param {Function} getUrl
  * @param {string} createElementTag
+ * @param {boolean} requirePlayer
  * @param {boolean} shouldSetDocumentTitle
  * @returns
  */
@@ -273,9 +276,11 @@ async function createOrUpdateUntranslatedFakeNode(
   originalNodeSelector,
   getUrl,
   createElementTag,
+  requirePlayer = true,
   shouldSetDocumentTitle = false,
 ) {
   if (
+    !requirePlayer ||
     window.YoutubeAntiTranslate.getFirstVisible(
       document.querySelectorAll(
         window.YoutubeAntiTranslate.getPlayerSelector(),

--- a/app/src/background.js
+++ b/app/src/background.js
@@ -489,7 +489,10 @@ async function untranslateOtherVideos(intersectElements = null) {
         }
 
         // Check if current widget is a playlist, not video
-        if (video.querySelector('a[href*="/playlist?"]')) {
+        if (
+          video.querySelector('a[href*="/playlist?"]') ||
+          video.querySelector("yt-collections-stack.collections-stack-wiz")
+        ) {
           return;
         }
 

--- a/app/src/background.js
+++ b/app/src/background.js
@@ -484,13 +484,7 @@ async function untranslateOtherVideos(intersectElements = null) {
         }
 
         // Check if current widget is a playlist, not video
-        if (
-          // Playlists include a "list=" parameter in their href
-          linkElement.href.includes("list=") &&
-          // Playlist do not include an "index=" parameter in their href
-          // Only videos in playlists include an "index=" parameter
-          !linkElement.href.includes("index=")
-        ) {
+        if (video.querySelector('a[href*="/playlist?"]')) {
           return;
         }
 

--- a/app/src/background.js
+++ b/app/src/background.js
@@ -437,6 +437,18 @@ async function untranslateOtherVideos(intersectElements = null) {
           return;
         }
 
+        // Check if current widget is a playlist, not video
+        if (
+          video.querySelector('a[href*="/playlist?"]') ||
+          window.YoutubeAntiTranslate.getFirstVisible(
+            video.querySelector(
+              "yt-collections-stack.collections-stack-wiz > .collections-stack-wiz__collection-stack1",
+            ),
+          )
+        ) {
+          return;
+        }
+
         // Find link and title elements typical for standard videos
         let linkElement =
           video.querySelector("a#video-title-link") ||
@@ -485,16 +497,6 @@ async function untranslateOtherVideos(intersectElements = null) {
 
         // Ignore advertisement video
         if (window.YoutubeAntiTranslate.isAdvertisementHref(linkElement.href)) {
-          return;
-        }
-
-        // Check if current widget is a playlist, not video
-        if (
-          video.querySelector('a[href*="/playlist?"]') ||
-          window.YoutubeAntiTranslate.isVisible(
-            video.querySelector("yt-collections-stack.collections-stack-wiz"),
-          )
-        ) {
           return;
         }
 

--- a/app/src/background.js
+++ b/app/src/background.js
@@ -442,7 +442,7 @@ async function untranslateOtherVideos(intersectElements = null) {
           video.querySelector('a[href*="/playlist?"]') ||
           window.YoutubeAntiTranslate.getFirstVisible(
             video.querySelector(
-              "yt-collections-stack.collections-stack-wiz > .collections-stack-wiz__collection-stack1",
+              "yt-collection-thumbnail-view-model, .media-item-thumbnail-container.stacked",
             ),
           )
         ) {

--- a/app/src/background.js
+++ b/app/src/background.js
@@ -492,7 +492,7 @@ async function untranslateOtherVideos(intersectElements = null) {
         if (
           video.querySelector('a[href*="/playlist?"]') ||
           window.YoutubeAntiTranslate.isVisible(
-             video.querySelector("yt-collections-stack.collections-stack-wiz"),
+            video.querySelector("yt-collections-stack.collections-stack-wiz"),
           )
         ) {
           return;

--- a/app/src/background.js
+++ b/app/src/background.js
@@ -491,7 +491,9 @@ async function untranslateOtherVideos(intersectElements = null) {
         // Check if current widget is a playlist, not video
         if (
           video.querySelector('a[href*="/playlist?"]') ||
-          video.querySelector("yt-collections-stack.collections-stack-wiz")
+          window.YoutubeAntiTranslate.isVisible(
+             video.querySelector("yt-collections-stack.collections-stack-wiz")
+          )
         ) {
           return;
         }

--- a/app/src/background.js
+++ b/app/src/background.js
@@ -492,7 +492,7 @@ async function untranslateOtherVideos(intersectElements = null) {
         if (
           video.querySelector('a[href*="/playlist?"]') ||
           window.YoutubeAntiTranslate.isVisible(
-             video.querySelector("yt-collections-stack.collections-stack-wiz")
+             video.querySelector("yt-collections-stack.collections-stack-wiz"),
           )
         ) {
           return;

--- a/app/src/background_description.js
+++ b/app/src/background_description.js
@@ -600,7 +600,7 @@ function fetchOriginalAuthor() {
     return null;
   }
 
-  return playerResponse.videoDetails?.author || null;
+  return playerResponse?.videoDetails?.author || null;
 }
 
 /**

--- a/app/src/content_channelbranding.js
+++ b/app/src/content_channelbranding.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unreachable */
 // Support both desktop and mobile YouTube layouts
 const CHANNELBRANDING_HEADER_SELECTOR =
   "#page-header-container #page-header .page-header-view-model-wiz__page-header-headline-info, .page-header-view-model-wiz__page-header-headline-info";
@@ -571,7 +570,7 @@ function updateBrandingAboutDescriptionContent(
     if (
       descriptionTextContainer.hasChildNodes() &&
       descriptionTextContainer.firstChild.textContent !==
-      formattedContent.textContent
+        formattedContent.textContent
     ) {
       window.YoutubeAntiTranslate.replaceContainerContent(
         descriptionTextContainer,
@@ -753,7 +752,9 @@ async function restoreCollaboratorsDialog() {
     return;
   }
 
-  const listItems = dialog.querySelectorAll("yt-list-item-view-model.yt-list-item-view-model-wiz");
+  const listItems = dialog.querySelectorAll(
+    "yt-list-item-view-model.yt-list-item-view-model-wiz",
+  );
   if (!listItems || listItems.length === 0) {
     return;
   }
@@ -784,7 +785,12 @@ async function restoreCollaboratorsDialog() {
     }
 
     // Replace only the first text node inside the link to preserve icons/badges
-    if (!window.YoutubeAntiTranslate.isStringEqual(linkEl.textContent?.trim(), branding.title)) {
+    if (
+      !window.YoutubeAntiTranslate.isStringEqual(
+        linkEl.textContent?.trim(),
+        branding.title,
+      )
+    ) {
       window.YoutubeAntiTranslate.replaceTextOnly(linkEl, branding.title);
     }
 

--- a/app/src/content_channelbranding.js
+++ b/app/src/content_channelbranding.js
@@ -759,7 +759,7 @@ async function restoreCollaboratorsDialog() {
     return;
   }
 
-  const tasks = listItems.map(async (item) => {
+  const tasks = Array.from(listItems).map(async (item) => {
     if (item.getAttribute("data-ytat-collab-untranslated") === "true") {
       return;
     }

--- a/app/src/content_channelbranding.js
+++ b/app/src/content_channelbranding.js
@@ -571,7 +571,7 @@ function updateBrandingAboutDescriptionContent(
     if (
       descriptionTextContainer.hasChildNodes() &&
       descriptionTextContainer.firstChild.textContent !==
-        formattedContent.textContent
+      formattedContent.textContent
     ) {
       window.YoutubeAntiTranslate.replaceContainerContent(
         descriptionTextContainer,
@@ -599,9 +599,17 @@ async function untranslateBranding() {
   if (isChannelPage) {
     const brandingHeaderPromise = restoreOriginalBrandingHeader();
     const brandingAboutPromise = restoreOriginalBrandingAbout();
-    await Promise.all([brandingHeaderPromise, brandingAboutPromise]);
+    const collaboratorsPromise = restoreCollaboratorsDialog();
+    await Promise.all([
+      brandingHeaderPromise,
+      brandingAboutPromise,
+      collaboratorsPromise,
+    ]);
   } else {
-    await restoreOriginalBrandingSearchResults();
+    await Promise.all([
+      restoreOriginalBrandingSearchResults(),
+      restoreCollaboratorsDialog(),
+    ]);
   }
 }
 
@@ -728,6 +736,59 @@ async function restoreOriginalBrandingSearchResults() {
 
     updateSearchResultDescriptionContent(renderer, originalBrandingData);
     updateSearchResultChannelAuthor(renderer, originalBrandingData);
+  });
+
+  await Promise.allSettled(tasks);
+}
+
+/**
+ * Restores original channel names in the collaborators popup dialog.
+ */
+async function restoreCollaboratorsDialog() {
+  // Find any open dialog that lists channels
+  const dialog = window.YoutubeAntiTranslate.getFirstVisible(
+    document.querySelectorAll("yt-dialog-view-model"),
+  );
+  if (!dialog) {
+    return;
+  }
+
+  const listItems = dialog.querySelectorAll("yt-list-item-view-model.yt-list-item-view-model-wiz");
+  if (!listItems || listItems.length === 0) {
+    return;
+  }
+
+  const tasks = listItems.map(async (item) => {
+    if (item.getAttribute("data-ytat-collab-untranslated") === "true") {
+      return;
+    }
+
+    // Anchor that contains the channel name (bold title area)
+    const linkEl =
+      item.querySelector(
+        ".yt-list-item-view-model-wiz__title-wrapper a.yt-core-attributed-string__link",
+      ) || item.querySelector("a.yt-core-attributed-string__link");
+    if (!linkEl) {
+      return;
+    }
+
+    const href = linkEl.getAttribute("href");
+    const ucid = await getChannelUCIDFromHref(href);
+    if (!ucid) {
+      return;
+    }
+
+    const branding = await getChannelBrandingWithYoutubeI(ucid);
+    if (!branding || !branding.title) {
+      return;
+    }
+
+    // Replace only the first text node inside the link to preserve icons/badges
+    if (!window.YoutubeAntiTranslate.isStringEqual(linkEl.textContent?.trim(), branding.title)) {
+      window.YoutubeAntiTranslate.replaceTextOnly(linkEl, branding.title);
+    }
+
+    item.setAttribute("data-ytat-collab-untranslated", "true");
   });
 
   await Promise.allSettled(tasks);

--- a/tests-unit/debounce.test.js
+++ b/tests-unit/debounce.test.js
@@ -24,7 +24,7 @@ describe("YoutubeAntiTranslate.debounce", () => {
     vi.useFakeTimers();
     installRAFStub();
     // Ensure default visibility unless the test overrides it
-    Object.defineProperty(document, "hidden", {
+    Object.defineProperty(document, "visible", {
       value: false,
       configurable: true,
     });
@@ -37,6 +37,8 @@ describe("YoutubeAntiTranslate.debounce", () => {
 
   it("executes immediately and throttles subsequent calls when document is visible", () => {
     const fn = vi.fn();
+    const rafSpy = vi.spyOn(global, "requestAnimationFrame");
+
     const debounced = debounce(fn, 30);
 
     // First call runs immediately
@@ -54,6 +56,9 @@ describe("YoutubeAntiTranslate.debounce", () => {
     vi.advanceTimersByTime(20); // total 35ms > 30ms
     vi.runOnlyPendingTimers();
     expect(fn).toHaveBeenCalledTimes(2);
+
+    // Should have called requestAnimationFrame
+    expect(rafSpy).toHaveBeenCalled();
   });
 
   it("falls back to setTimeout when document is hidden", () => {

--- a/tests-unit/debounce.test.js
+++ b/tests-unit/debounce.test.js
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Side-effect import that registers the util object on window
+import "../app/src/global.js";
+
+const { debounce } = window.YoutubeAntiTranslate;
+
+/**
+ * Helper: install a requestAnimationFrame stub that uses setTimeout(0)
+ * so it cooperates with Vitest's fake-timer clock.
+ */
+function installRAFStub() {
+  global.requestAnimationFrame = (cb) => setTimeout(() => cb(Date.now()), 0);
+  global.cancelAnimationFrame = (id) => clearTimeout(id);
+}
+
+function restoreRAFStub() {
+  delete global.requestAnimationFrame;
+  delete global.cancelAnimationFrame;
+}
+
+describe("YoutubeAntiTranslate.debounce", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    installRAFStub();
+    // Ensure default visibility unless the test overrides it
+    Object.defineProperty(document, "hidden", {
+      value: false,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    restoreRAFStub();
+  });
+
+  it("executes immediately and throttles subsequent calls when document is visible", () => {
+    const fn = vi.fn();
+    const debounced = debounce(fn, 30);
+
+    // First call runs immediately
+    debounced();
+    vi.runOnlyPendingTimers();
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // Second call within the wait window should schedule but not run yet
+    debounced();
+    vi.advanceTimersByTime(15); // half of wait window
+    vi.runOnlyPendingTimers();
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // After the wait window, the scheduled call should execute
+    vi.advanceTimersByTime(20); // total 35ms > 30ms
+    vi.runOnlyPendingTimers();
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to setTimeout when document is hidden", () => {
+    // Simulate background tab
+    Object.defineProperty(document, "hidden", {
+      value: true,
+      configurable: true,
+    });
+
+    const fn = vi.fn();
+    const debounced = debounce(fn, 30);
+
+    const setTimeoutSpy = vi.spyOn(global, "setTimeout");
+    const rafSpy = vi.spyOn(global, "requestAnimationFrame");
+
+    debounced();
+
+    // Should skip RAF and use setTimeout for scheduling
+    expect(setTimeoutSpy).toHaveBeenCalled();
+    expect(rafSpy).not.toHaveBeenCalled();
+
+    // Execute timers to allow the debounced function to run
+    vi.runAllTimers();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/youtube-extension.extra.spec.ts
+++ b/tests/youtube-extension.extra.spec.ts
@@ -63,6 +63,65 @@ test.describe("YouTube Anti-Translate extension - Extras", () => {
     );
   });
 
+  test("Collaborators popup on video opens via #upload-info and retains original names (th-TH)", async ({
+    browserNameWithExtensions,
+    localeString,
+  }, testInfo) => {
+    await handleRetrySetup(testInfo, browserNameWithExtensions, localeString);
+
+    const context = await createBrowserContext(browserNameWithExtensions);
+
+    const { page, consoleMessageCountContainer } = await setupPageWithAuth(
+      context,
+      browserNameWithExtensions,
+      localeString,
+    );
+
+    // Navigate to the provided video
+    await loadPageAndVerifyAuth(
+      page,
+      "https://www.youtube.com/watch?v=Z4hVGCWH1Kc",
+      browserNameWithExtensions,
+    );
+
+    // Wait for the upload info block, scroll into view, and click as requested
+    const uploadInfo = page.locator("#channel-name").first();
+    await expect(uploadInfo).toBeVisible({ timeout: 20000 });
+    await uploadInfo.scrollIntoViewIfNeeded();
+    await uploadInfo.click();
+    try {
+      await page.waitForLoadState("networkidle", { timeout: 5000 });
+    } catch { }
+    await page.waitForTimeout(1000);
+
+    // Expect a dialog to appear listing collaborators
+    const collabItems = page.locator(
+      'yt-dialog-view-model .yt-list-item-view-model-wiz__title-wrapper a.yt-core-attributed-string__link',
+    );
+
+    // Allow enough time for the extension to fetch and update names
+    await expect(collabItems.first()).toBeAttached({ timeout: 20000 });
+    await page.waitForTimeout(3000);
+
+    const names = (await collabItems.allTextContents()).map((n) => (n || "").trim());
+    expect(names.length).toBeGreaterThan(0);
+
+    // Validate that collaborator names are not in Thai (i.e., un-translated)
+    const thaiRegex = /[\u0E00-\u0E7F]/;
+    for (const name of names) {
+      expect(thaiRegex.test(name)).toBeFalsy();
+    }
+
+    // Screenshot for visual verification
+    await page.screenshot({
+      path: `images/tests/${browserNameWithExtensions}/${localeString}/youtube-collaborators-dialog-from-upload-info-test.png`,
+    });
+
+    expect(consoleMessageCountContainer.count).toBeLessThan(2000);
+
+    await context.close();
+  });
+
   async function channelBrandingAboutTest(
     context: BrowserContext | Browser,
     browserNameWithExtensions: string,
@@ -124,7 +183,7 @@ test.describe("YouTube Anti-Translate extension - Extras", () => {
       .click();
     try {
       await page.waitForLoadState("networkidle", { timeout: 5000 });
-    } catch {}
+    } catch { }
     await page.waitForTimeout(500);
 
     // --- Check About Popup ---
@@ -161,7 +220,7 @@ test.describe("YouTube Anti-Translate extension - Extras", () => {
       .click();
     try {
       await page.waitForLoadState("networkidle", { timeout: 5000 });
-    } catch {}
+    } catch { }
     await page.waitForTimeout(500);
 
     // --- Open About Popup via more links ---
@@ -175,7 +234,7 @@ test.describe("YouTube Anti-Translate extension - Extras", () => {
       .click();
     try {
       await page.waitForLoadState("networkidle", { timeout: 5000 });
-    } catch {}
+    } catch { }
     await page.waitForTimeout(500);
 
     // --- Check About A second time via the moreLinks Popup ---
@@ -212,7 +271,7 @@ test.describe("YouTube Anti-Translate extension - Extras", () => {
       .click();
     try {
       await page.waitForLoadState("networkidle", { timeout: 5000 });
-    } catch {}
+    } catch { }
     await page.waitForTimeout(500);
 
     // Take a screenshot for visual verification

--- a/tests/youtube-extension.extra.spec.ts
+++ b/tests/youtube-extension.extra.spec.ts
@@ -91,18 +91,20 @@ test.describe("YouTube Anti-Translate extension - Extras", () => {
     await uploadInfo.click();
     try {
       await page.waitForLoadState("networkidle", { timeout: 5000 });
-    } catch { }
+    } catch {}
     await page.waitForTimeout(1000);
 
     // Expect a dialog to appear listing collaborators
     const collabItems = page.locator(
-      'yt-dialog-view-model .yt-list-item-view-model-wiz__title-wrapper a.yt-core-attributed-string__link',
+      "yt-dialog-view-model .yt-list-item-view-model-wiz__title-wrapper a.yt-core-attributed-string__link",
     );
 
     // Allow enough time for the extension to fetch and update names
     await expect(collabItems.first()).toBeAttached({ timeout: 20000 });
 
-    const names = (await collabItems.allTextContents()).map((n) => (n || "").trim());
+    const names = (await collabItems.allTextContents()).map((n) =>
+      (n || "").trim(),
+    );
     expect(names.length).toBeGreaterThan(0);
 
     // Validate that collaborator names are not in Thai (i.e., un-translated)
@@ -182,7 +184,7 @@ test.describe("YouTube Anti-Translate extension - Extras", () => {
       .click();
     try {
       await page.waitForLoadState("networkidle", { timeout: 5000 });
-    } catch { }
+    } catch {}
     await page.waitForTimeout(500);
 
     // --- Check About Popup ---
@@ -219,7 +221,7 @@ test.describe("YouTube Anti-Translate extension - Extras", () => {
       .click();
     try {
       await page.waitForLoadState("networkidle", { timeout: 5000 });
-    } catch { }
+    } catch {}
     await page.waitForTimeout(500);
 
     // --- Open About Popup via more links ---
@@ -233,7 +235,7 @@ test.describe("YouTube Anti-Translate extension - Extras", () => {
       .click();
     try {
       await page.waitForLoadState("networkidle", { timeout: 5000 });
-    } catch { }
+    } catch {}
     await page.waitForTimeout(500);
 
     // --- Check About A second time via the moreLinks Popup ---
@@ -270,7 +272,7 @@ test.describe("YouTube Anti-Translate extension - Extras", () => {
       .click();
     try {
       await page.waitForLoadState("networkidle", { timeout: 5000 });
-    } catch { }
+    } catch {}
     await page.waitForTimeout(500);
 
     // Take a screenshot for visual verification

--- a/tests/youtube-extension.extra.spec.ts
+++ b/tests/youtube-extension.extra.spec.ts
@@ -101,7 +101,6 @@ test.describe("YouTube Anti-Translate extension - Extras", () => {
 
     // Allow enough time for the extension to fetch and update names
     await expect(collabItems.first()).toBeAttached({ timeout: 20000 });
-    await page.waitForTimeout(3000);
 
     const names = (await collabItems.allTextContents()).map((n) => (n || "").trim());
     expect(names.length).toBeGreaterThan(0);


### PR DESCRIPTION
Closes #106, #112, #108, #109, #110, #105
Looks like new chrome update changed how rAF in background works.

This PR uses setTimeout in background.

How to test:
1. Windows, chrome 139
2. Use EN locale and open this video https://www.youtube.com/watch?v=0xcZ_RdXZSA
3. Open another tab
4. Reload opened video and quickly switch to another tab
5. On 1.19.9 after some time title become english, while on 1.19.10 it will always change to russian one.