### PR TITLE
Fix for video titles not being restored on the homepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.19.12] - 2025-08-29
+
+- [#122](https://github.com/zpix1/yt-anti-translate/issues/122) YouTube classes change
+
 ## [1.19.11] - 2025-08-20
 
 - [#117](https://github.com/zpix1/yt-anti-translate/issues/117) Untranslate channel branding unicode issue

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "YouTube Anti Translate",
   "author": "zpix1",
-  "version": "1.19.11",
+  "version": "1.19.12",
   "description": "A small extension to disable YouTube video titles/audio/descriptions autotranslation.",
   "manifest_version": 3,
   "browser_specific_settings": {

--- a/app/pages/popup.html
+++ b/app/pages/popup.html
@@ -239,7 +239,7 @@
   <body id="yt-anti-translate">
     <div class="scroll-wrapper">
       <div class="container">
-        <div class="header">YT Anti Translate 1.19.11</div>
+        <div class="header">YT Anti Translate 1.19.12</div>
         <div id="permission-warning" style="display: none; margin-top: 15px;">
           <div class="small" style="color: red;">
             <p><strong>Permission to access YouTube is not granted.</strong></p>

--- a/app/src/background.js
+++ b/app/src/background.js
@@ -453,13 +453,12 @@ async function untranslateOtherVideos(intersectElements = null) {
         let linkElement =
           video.querySelector("a#video-title-link") ||
           video.querySelector("a#thumbnail") ||
-          video.querySelector("a.yt-lockup-metadata-view-model__title") ||
           video.querySelector("a.media-item-thumbnail-container") ||
           video.querySelector("ytd-playlist-panel-video-renderer a") ||
           video.querySelector("ytm-video-card-renderer a") ||
-          video.querySelector("a.media-item-thumbnail-container");
+          video.querySelector("a.media-item-thumbnail-container") ||
+          video.querySelector("a.yt-lockup-metadata-view-model__title");
         let titleElement =
-          video.querySelector("h3.yt-lockup-metadata-view-model__heading-reset > a > span") ||
           video.querySelector("#video-title:not(.cbCustomTitle)") ||
           video.querySelector(
             ".compact-media-item-headline .yt-core-attributed-string",
@@ -472,6 +471,9 @@ async function untranslateOtherVideos(intersectElements = null) {
           ) ||
           video.querySelector(
             ".media-item-headline .yt-core-attributed-string",
+          ) ||
+          video.querySelector(
+            ".yt-lockup-metadata-view-model__heading-reset .yt-core-attributed-string",
           );
 
         if (!linkElement || !titleElement) {

--- a/app/src/background.js
+++ b/app/src/background.js
@@ -450,7 +450,7 @@ async function untranslateOtherVideos(intersectElements = null) {
         }
 
         // Find link and title elements typical for standard videos
-        let linkElement =
+          let linkElement =
           video.querySelector("a#video-title-link") ||
           video.querySelector("a#thumbnail") ||
           video.querySelector("a.media-item-thumbnail-container") ||
@@ -458,6 +458,7 @@ async function untranslateOtherVideos(intersectElements = null) {
           video.querySelector("ytm-video-card-renderer a") ||
           video.querySelector("a.media-item-thumbnail-container");
         let titleElement =
+          video.querySelector("h3.yt-lockup-metadata-view-model__heading-reset > a > span") ||
           video.querySelector("#video-title:not(.cbCustomTitle)") ||
           video.querySelector(
             ".compact-media-item-headline .yt-core-attributed-string",

--- a/app/src/background.js
+++ b/app/src/background.js
@@ -453,6 +453,7 @@ async function untranslateOtherVideos(intersectElements = null) {
           let linkElement =
           video.querySelector("a#video-title-link") ||
           video.querySelector("a#thumbnail") ||
+          video.querySelector("a.yt-lockup-metadata-view-model__title") ||
           video.querySelector("a.media-item-thumbnail-container") ||
           video.querySelector("ytd-playlist-panel-video-renderer a") ||
           video.querySelector("ytm-video-card-renderer a") ||

--- a/app/src/background.js
+++ b/app/src/background.js
@@ -456,7 +456,6 @@ async function untranslateOtherVideos(intersectElements = null) {
           video.querySelector("a.media-item-thumbnail-container") ||
           video.querySelector("ytd-playlist-panel-video-renderer a") ||
           video.querySelector("ytm-video-card-renderer a") ||
-          video.querySelector("a.media-item-thumbnail-container") ||
           video.querySelector("a.yt-lockup-metadata-view-model__title");
         let titleElement =
           video.querySelector("#video-title:not(.cbCustomTitle)") ||

--- a/app/src/background.js
+++ b/app/src/background.js
@@ -450,7 +450,7 @@ async function untranslateOtherVideos(intersectElements = null) {
         }
 
         // Find link and title elements typical for standard videos
-          let linkElement =
+        let linkElement =
           video.querySelector("a#video-title-link") ||
           video.querySelector("a#thumbnail") ||
           video.querySelector("a.yt-lockup-metadata-view-model__title") ||

--- a/app/src/content_channelbranding.js
+++ b/app/src/content_channelbranding.js
@@ -1,6 +1,6 @@
 // Support both desktop and mobile YouTube layouts
 const CHANNELBRANDING_HEADER_SELECTOR =
-  "#page-header-container #page-header .page-header-view-model-wiz__page-header-headline-info, .page-header-view-model-wiz__page-header-headline-info, #page-header";
+  "#page-header-container #page-header .page-header-view-model-wiz__page-header-headline-info, .page-header-view-model-wiz__page-header-headline-info, .page-header-view-model__page-header-headline-info, .yt-page-header-view-model__page-header-headline-info, #page-header";
 const CHANNELBRANDING_ABOUT_SELECTOR =
   "ytd-engagement-panel-section-list-renderer, ytm-engagement-panel-section-list-renderer";
 const CHANNEL_LOCATION_REGEXES = [

--- a/app/src/content_channelbranding.js
+++ b/app/src/content_channelbranding.js
@@ -1,6 +1,6 @@
 // Support both desktop and mobile YouTube layouts
 const CHANNELBRANDING_HEADER_SELECTOR =
-  "#page-header-container #page-header .page-header-view-model-wiz__page-header-headline-info, .page-header-view-model-wiz__page-header-headline-info";
+  "#page-header-container #page-header .page-header-view-model-wiz__page-header-headline-info, .page-header-view-model-wiz__page-header-headline-info, #page-header";
 const CHANNELBRANDING_ABOUT_SELECTOR =
   "ytd-engagement-panel-section-list-renderer, ytm-engagement-panel-section-list-renderer";
 const CHANNEL_LOCATION_REGEXES = [
@@ -392,17 +392,14 @@ function updateBrandingHeaderDescriptionContent(
 ) {
   if (originalBrandingData.description) {
     // Find the description text container
+    const selector = `yt-description-preview-view-model .yt-truncated-text__truncated-text-content > ${window.YoutubeAntiTranslate.CORE_ATTRIBUTED_STRING_SELECTOR},:nth-child(1), yt-description-preview-view-model .truncated-text-wiz__truncated-text-content > ${window.YoutubeAntiTranslate.CORE_ATTRIBUTED_STRING_SELECTOR}:nth-child(1)`;
 
-    let descriptionTextContainer = container.querySelector(
-      `yt-description-preview-view-model .truncated-text-wiz__truncated-text-content > ${window.YoutubeAntiTranslate.CORE_ATTRIBUTED_STRING_SELECTOR}:nth-child(1)`,
-    );
+    let descriptionTextContainer = container.querySelector(selector);
 
     // When width is lower than 528px the text container is outside the main container
     if (!descriptionTextContainer) {
       descriptionTextContainer = window.YoutubeAntiTranslate.getFirstVisible(
-        document.querySelector(
-          `yt-description-preview-view-model .truncated-text-wiz__truncated-text-content > ${window.YoutubeAntiTranslate.CORE_ATTRIBUTED_STRING_SELECTOR}:nth-child(1)`,
-        ),
+        document.querySelector(selector),
       );
     }
 

--- a/app/src/content_channelbranding.js
+++ b/app/src/content_channelbranding.js
@@ -765,7 +765,7 @@ async function restoreCollaboratorsDialog() {
   }
 
   const listItems = dialog.querySelectorAll(
-    "yt-list-item-view-model.yt-list-item-view-model-wiz",
+    "yt-list-item-view-model .yt-list-item-view-model__text-wrapper",
   );
   if (!listItems || listItems.length === 0) {
     return;
@@ -779,7 +779,7 @@ async function restoreCollaboratorsDialog() {
     // Anchor that contains the channel name (bold title area)
     const linkEl =
       item.querySelector(
-        ".yt-list-item-view-model-wiz__title-wrapper a.yt-core-attributed-string__link",
+        ".yt-list-item-view-model__text-wrapper a.yt-core-attributed-string__link",
       ) || item.querySelector("a.yt-core-attributed-string__link");
     if (!linkEl) {
       return;

--- a/app/src/content_channelbranding.js
+++ b/app/src/content_channelbranding.js
@@ -392,7 +392,7 @@ function updateBrandingHeaderDescriptionContent(
 ) {
   if (originalBrandingData.description) {
     // Find the description text container
-    const selector = `yt-description-preview-view-model .yt-truncated-text__truncated-text-content > ${window.YoutubeAntiTranslate.CORE_ATTRIBUTED_STRING_SELECTOR},:nth-child(1), yt-description-preview-view-model .truncated-text-wiz__truncated-text-content > ${window.YoutubeAntiTranslate.CORE_ATTRIBUTED_STRING_SELECTOR}:nth-child(1)`;
+    const selector = `yt-description-preview-view-model .yt-truncated-text__truncated-text-content > ${window.YoutubeAntiTranslate.CORE_ATTRIBUTED_STRING_SELECTOR}:nth-child(1), yt-description-preview-view-model .truncated-text-wiz__truncated-text-content > ${window.YoutubeAntiTranslate.CORE_ATTRIBUTED_STRING_SELECTOR}:nth-child(1)`;
 
     let descriptionTextContainer = container.querySelector(selector);
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,7 +16,7 @@ export const test = base.extend<TestOptions>({
 });
 
 export default defineConfig<TestOptions>({
-  timeout: 960_000,
+  timeout: 2 * 60 * 1000,
   testDir: "./tests",
   /* Run tests in files in parallel */
   fullyParallel: true,

--- a/tests/youtube-extension.extra.spec.ts
+++ b/tests/youtube-extension.extra.spec.ts
@@ -138,8 +138,7 @@ test.describe("YouTube Anti-Translate extension - Extras", () => {
     await loadPageAndVerifyAuth(page, "https://www.youtube.com/@MrBeast");
 
     // Wait for the video grid to appear
-    const channelHeaderSelector =
-      "#page-header-container #page-header .page-header-view-model-wiz__page-header-headline-info";
+    const channelHeaderSelector = "#page-header-container #page-header";
     await page.waitForSelector(channelHeaderSelector);
 
     // --- Check Branding Title ---
@@ -158,7 +157,7 @@ test.describe("YouTube Anti-Translate extension - Extras", () => {
     await expect(page.locator(channelTitleSelector)).toBeVisible();
 
     // --- Check Branding Description
-    const channelDescriptionSelector = `${channelHeaderSelector} yt-description-preview-view-model .truncated-text-wiz__truncated-text-content > .yt-core-attributed-string:nth-child(1)`;
+    const channelDescriptionSelector = `${channelHeaderSelector} yt-description-preview-view-model .yt-truncated-text__truncated-text-content > .yt-core-attributed-string:nth-child(1)`;
 
     console.log("Checking Channel header for original description...");
     // Get the channel branding header description
@@ -180,7 +179,9 @@ test.describe("YouTube Anti-Translate extension - Extras", () => {
       "Clicking '..more' button on description to open About Popup...",
     );
     await page
-      .locator(`${channelHeaderSelector} .truncated-text-wiz__absolute-button`)
+      .locator(
+        `${channelHeaderSelector} truncated-text .yt-truncated-text__absolute-button`,
+      )
       .click();
     try {
       await page.waitForLoadState("networkidle", { timeout: 5000 });
@@ -429,12 +430,11 @@ test.describe("YouTube Anti-Translate extension - Extras", () => {
     await loadPageAndVerifyAuth(page, channelUrl, browserNameWithExtensions);
 
     // Wait for the channel header to appear
-    const channelHeaderSelector =
-      "#page-header-container #page-header .page-header-view-model-wiz__page-header-headline-info";
+    const channelHeaderSelector = "#page-header-container #page-header";
     await page.waitForSelector(channelHeaderSelector);
 
     // Check channel description
-    const channelDescriptionSelector = `${channelHeaderSelector} yt-description-preview-view-model .truncated-text-wiz__truncated-text-content > .yt-core-attributed-string:nth-child(1)`;
+    const channelDescriptionSelector = `${channelHeaderSelector} yt-description-preview-view-model .yt-truncated-text__truncated-text-content > .yt-core-attributed-string:nth-child(1)`;
 
     // Get the channel description
     const brandingDescription = await page

--- a/tests/youtube-extension.extra.spec.ts
+++ b/tests/youtube-extension.extra.spec.ts
@@ -96,7 +96,7 @@ test.describe("YouTube Anti-Translate extension - Extras", () => {
 
     // Expect a dialog to appear listing collaborators
     const collabItems = page.locator(
-      "yt-dialog-view-model .yt-list-item-view-model-wiz__title-wrapper a.yt-core-attributed-string__link",
+      "yt-dialog-view-model .yt-list-item-view-model__text-wrapper a.yt-core-attributed-string__link",
     );
 
     // Allow enough time for the extension to fetch and update names

--- a/tests/youtube-extension.spec.ts
+++ b/tests/youtube-extension.spec.ts
@@ -763,7 +763,7 @@ test.describe("YouTube Anti-Translate extension", () => {
     );
     // Locate the elements with the text "Popular Shorts"
     const popularShortsLocator = page.locator(
-      'div.yt-lockup-metadata-view-model-wiz__text-container > h3 > a > span:has-text("Popular Shorts")',
+      '.yt-lockup-metadata-view-model__heading-reset span:has-text("Popular Shorts")',
     );
 
     // Assert that at least one matching element exists

--- a/tests/youtube-extension.spec.ts
+++ b/tests/youtube-extension.spec.ts
@@ -99,11 +99,13 @@ test.describe("YouTube Anti-Translate extension", () => {
 
     // Get the full screen footer video title
     const fullStreenVideoTitleFooter = await page
-      .locator(
-        "ytd-player .html5-video-player div.ytp-fullerscreen-edu-text#yt-anti-translate-fake-node-fullscreen-edu",
-      )
+      .locator(".ytp-title-text .ytp-title-fullerscreen-link")
+      .nth(1)
       .textContent();
-    console.log("Head Link Video title:", fullStreenVideoTitleFooter?.trim());
+    console.log(
+      "Full Screen Head Link Video title:",
+      fullStreenVideoTitleFooter?.trim(),
+    );
 
     // Check that the title is in English and not in Russian
     expect(fullStreenVideoTitleFooter).toContain(


### PR DESCRIPTION
Recently the extension was no longer working on the homepage for me. Apparently YouTube recently changed the way titles are rendered on the homepage. After adding video.querySelector() to linkElement and titleElement() it seems to work again.