### PR TITLE
[CI-FIX] Separate lint/vitest from playwright, so that lint/vitest can be run at every push/pull_request event

### DIFF
--- a/.github/workflows/lint-and-vitest.yml
+++ b/.github/workflows/lint-and-vitest.yml
@@ -1,0 +1,29 @@
+name: Lint and Unit Vitests
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint-and-vitest:
+    name: Lint and Unit Vitests
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR code or main
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Run unit tests
+        run: npm run test:unit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,16 +40,16 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
+
       - name: Install dependencies
         run: npm ci
-      - name: Lint
-        run: npm run lint
-      - name: Run unit tests
-        run: npm run test:unit
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
+
       - name: Set up virtual display
         run: sudo apt-get update && sudo apt-get install -y xvfb
+
       - name: Run Playwright tests
         env:
           YOUTUBE_API_KEY: "${{ secrets.YOUTUBE_API_KEY }}"
@@ -57,12 +57,14 @@ jobs:
           GOOGLE_PWD: "${{ secrets.GOOGLE_PWD }}"
           GOOGLE_OTP_SECRET: "${{ secrets.GOOGLE_OTP_SECRET }}"
         run: xvfb-run npx playwright test --headed
+
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
+
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:


### PR DESCRIPTION
Separate lint/vitest from playwright, so that lint/vitest can be run at every push/pull_request event