### PR TITLE
Fix description profile link styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased 
+## Unreleased
+
+## [1.20.4.3] - 2026-04-20
+
+### Fixed
+
+- Fix [#177](https://github.com/zpix1/yt-anti-translate/issues/177) profile link styling in video descriptions
 
 ## [1.20.4.2] - 2026-04-11
 

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "YouTube Anti Translate",
   "author": "zpix1",
-  "version": "1.20.4.2",
+  "version": "1.20.4.3",
   "description": "A small extension to disable YouTube video titles/audio/descriptions autotranslation.",
   "manifest_version": 3,
   "browser_specific_settings": {

--- a/app/pages/popup.html
+++ b/app/pages/popup.html
@@ -463,7 +463,7 @@
 <body id="yt-anti-translate">
   <div class="scroll-wrapper">
     <div class="container">
-      <div class="header">YT Anti Translate 1.20.4.2</div>
+      <div class="header">YT Anti Translate 1.20.4.3</div>
       <div id="permission-warning" style="display: none; margin-top: 15px;">
         <div class="limited-width-container">
           <div class="small" style="color: red;">

--- a/app/src/global.js
+++ b/app/src/global.js
@@ -774,7 +774,8 @@ ytm-shorts-lockup-view-model`,
 
     // Create the container span
     const span = document.createElement("span");
-    span.className = "yt-core-attributed-string--link-inherit-color";
+    span.className =
+      "yt-core-attributed-string--link-inherit-color ytAttributedStringLinkInheritColor";
     span.dir = "auto";
     span.style.color = this.isDarkTheme()
       ? "rgb(62, 166, 255)"
@@ -783,7 +784,7 @@ ytm-shorts-lockup-view-model`,
     // Create the anchor element
     const link = document.createElement("a");
     link.className =
-      "yt-core-attributed-string__link yt-core-attributed-string__link--call-to-action-color yt-timecode-link";
+      "yt-core-attributed-string__link yt-core-attributed-string__link--call-to-action-color ytAttributedStringLink ytAttributedStringLinkCallToActionColor yt-timecode-link";
     link.tabIndex = 0;
     link.href = `/watch?v=${this.getCurrentVideoId()}&t=${seconds}s`;
     link.target = "";
@@ -800,7 +801,8 @@ ytm-shorts-lockup-view-model`,
 
     // Create the container span
     const span = document.createElement("span");
-    span.className = "yt-core-attributed-string--link-inherit-color";
+    span.className =
+      "yt-core-attributed-string--link-inherit-color ytAttributedStringLinkInheritColor";
     span.dir = "auto";
     span.style.color = this.isDarkTheme()
       ? "rgb(62, 166, 255)"
@@ -809,7 +811,7 @@ ytm-shorts-lockup-view-model`,
     // Create the anchor element
     const link = document.createElement("a");
     link.className =
-      "yt-core-attributed-string__link yt-core-attributed-string__link--call-to-action-color";
+      "yt-core-attributed-string__link yt-core-attributed-string__link--call-to-action-color ytAttributedStringLink ytAttributedStringLinkCallToActionColor";
     link.tabIndex = 0;
     if (type === "hashtag") {
       link.href = `/hashtag/${encodeURIComponent(value)}`;
@@ -922,7 +924,7 @@ ytm-shorts-lockup-view-model`,
     );
     const contentElement = document.createElement("span");
     contentElement.className =
-      "yt-core-attributed-string yt-core-attributed-string--white-space-pre-wrap";
+      "yt-core-attributed-string yt-core-attributed-string--white-space-pre-wrap ytAttributedStringHost ytAttributedStringWhiteSpacePreWrap";
     contentElement.dir = "auto";
 
     const textLines = text.split("\n");


### PR DESCRIPTION
Fixes #177.

## Summary

- add the current `ytAttributedString...` classes to generated attributed string links
- keep legacy `yt-core-attributed-string...` classes for compatibility
- bump extension version to `1.20.4.3`
